### PR TITLE
fix: include imports so tests run independently

### DIFF
--- a/src/test/my-element_test.ts
+++ b/src/test/my-element_test.ts
@@ -6,6 +6,9 @@
 
 import {MyElement} from '../my-element.js';
 
+// needed in order to guarantee MyElement gets defined.
+import '../my-element.js';
+
 import {fixture, html} from '@open-wc/testing';
 
 const assert = chai.assert;


### PR DESCRIPTION
if you were to comment out the test that uses `instanceof`, the rest of
the tests would fail due to the import being tree shaken by typescript.
without the import, the code that puts MyElement into `customElements`
won't ever get ran.

this import ensures that the import stays no matter what kind of test
you write, thus ensuring that the `customElements` piece is ran.

credit to  @Westbrook for coming up with the solution