### PR TITLE
Fix eslint matching pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:watch": "tsc --watch",
     "clean": "rimraf my-element.{d.ts,d.ts.map,js,js.map} test/my-element.{d.ts,d.ts.map,js,js.map} test/my-element_test.{d.ts,d.ts.map,js,js.map}",
     "lint": "npm run lint:lit-analyzer && npm run lint:eslint",
-    "lint:eslint": "eslint 'src/**/*.ts'",
+    "lint:eslint": "eslint src/**/*.ts",
     "lint:lit-analyzer": "lit-analyzer",
     "format": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --ignore-path ./.eslintignore --write",
     "docs": "npm run docs:clean && npm run build && npm run analyze && npm run docs:build && npm run docs:assets && npm run docs:gen",


### PR DESCRIPTION
running npm run lint:eslint on Windows will fail due to invalid matching pattern.
```
Oops! Something went wrong! :(

ESLint: 6.8.0.

No files matching the pattern "'src/**/*.ts'" were found.
Please check for typing mistakes in the pattern.
```

This PR fixes the pattern to make `eslint` happy across all OS