### PR TITLE
fix: adjust root dir of wds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs:assets": "cp node_modules/prismjs/themes/prism-okaidia.css docs/",
     "docs:serve": "wds --root-dir=docs --node-resolve --watch",
     "analyze": "wca analyze \"src/**/*.ts\" --outFile custom-elements.json",
-    "serve": "wds --watch",
+    "serve": "wds -r dev --watch",
     "test": "wtr",
     "test:watch": "npm run test -- --watch",
     "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js"


### PR DESCRIPTION
The `npm run serve` script does not specify the correct root dir for wds,
so i adjusted it.