### PR TITLE
fix: swap deprecated terser plugin for new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@open-wc/testing": "^3.1.5",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^5.0.2",
+    "@rollup/plugin-terser": "^0.4.0",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "@web/dev-server": "^0.1.31",
@@ -63,7 +64,6 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.73.0",
     "rollup-plugin-summary": "^1.4.3",
-    "rollup-plugin-terser": "^7.0.2",
     "typescript": "~4.7.4"
   },
   "customElements": "custom-elements.json"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@
  */
 
 import summary from 'rollup-plugin-summary';
-import {terser} from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 


### PR DESCRIPTION
- [x] [`rollup-plugin-terser`](https://www.npmjs.com/package/rollup-plugin-terser) is deprecated in favor of [`@rollup/plugin-terser`](https://www.npmjs.com/package/@rollup/plugin-terser)
- [x] swap dep, update import