### PR TITLE
fix: 🐛 missing pnpm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
     "rollup": "^2.73.0",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~4.7.4"
+    "typescript": "~4.9.5",
+    "@lit/reactive-element": "^1.6.1",
+    "lit-element": "^3.2.2",
+    "lit-html": "^2.6.1"
   },
   "customElements": "custom-elements.json"
 }


### PR DESCRIPTION
Simple PR to fix the pnpm dependencies errors:

```log
Error while transforming node_modules/lit/index.js: 
Could not resolve import "@lit/reactive-element".

Error while transforming node_modules/lit/decorators.js: 
Could not resolve import "@lit/reactive-element/decorators/custom-element.js".

Error while transforming node_modules/lit/index.js: 
Could not resolve import "lit-element/lit-element.js".
```