### PR TITLE
Specify "types" in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2019",
     "module": "es2020",
     "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "types": ["mocha"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
By default TS will pull in any global modifying types that it finds - by specifying a types field it'll only pull in specific ones - which is usually a very small list of packages.

This fixes a current issue where @types/estree conflicts with @types/eslint causes `npm run build` to fail.  But neither set of typings is needed so specifying "types" avoids the issue.