### PR TITLE
Add installation instruction for running the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Install dependencies:
 
 ```bash
 npm i
+npx playwright install # For `npm test`
 ```
 
 ## Build


### PR DESCRIPTION
`npm test` requires `playwright` (headless browsers).